### PR TITLE
fix: ghrc -> ghcr typo

### DIFF
--- a/oci.bundle.cue
+++ b/oci.bundle.cue
@@ -10,7 +10,7 @@ bundle: {
 	instances: {
 		podinfo: {
 			module: {
-				url:     "oci://ghrc.io/nalum/timoni/modules/oci"
+				url:     "oci://ghcr.io/nalum/timoni/modules/oci"
 				version: "0.1.0"
 			}
 			namespace: "flux-system"


### PR DESCRIPTION
I saw an article about [ghrc.io being potentially malicious](https://bmitch.net/blog/2025-08-22-ghrc-appears-malicious/) and looked through GH to see how many typos are there.